### PR TITLE
Added docker compose yml to create a new mysql server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  db:
+    container_name: database
+    image: mysql:latest
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: xadvisor
+      MYSQL_USER: xadvisor
+      MYSQL_PASSWORD: xadvisor2024
+    ports:
+      - "3306:3306"


### PR DESCRIPTION
# Added
- Añadido MySQL como docker container para no tener que instalarlo en local.

# Changed
- None

# Deleted
- None

Sólo tienes que hacer un `docker compose up` para crear el container, recomiendo tener *Portainer CE (Community Edition)* para poder manejar mejor los container. No hagáis `docker compose up` cada vez que queráis iniciarlo, podéis hacer un `docker run`.